### PR TITLE
fix: Correct Domain project reference path in Application.csproj

### DIFF
--- a/TeknoRoma_OnionArchitecture_Final/Core/Application/Application.csproj
+++ b/TeknoRoma_OnionArchitecture_Final/Core/Application/Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Core\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The project reference was pointing to a non-existent path:
- Old: ..\Core\Domain\Domain.csproj (resolved to Core/Core/Domain/)
- New: ..\Domain\Domain.csproj (correctly resolves to Core/Domain/)

This fixes the metadata build error where Application.dll could not be found.