### PR TITLE
fix: Correct property names in MVC and API controllers

### DIFF
--- a/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/ProductsController.cs
+++ b/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/ProductsController.cs
@@ -266,8 +266,8 @@ namespace WebAPI.Controllers
                 return NotFoundResponse($"ID: {id} olan urun bulunamadi");
 
             // Stok negatife dusemez kontrolu
-            if (product.Stock + quantityChange < 0)
-                return BadRequestResponse("Yetersiz stok. Mevcut: " + product.Stock);
+            if (product.UnitsInStock + quantityChange < 0)
+                return BadRequestResponse("Yetersiz stok. Mevcut: " + product.UnitsInStock);
 
             await _unitOfWork.Products.UpdateStockAsync(id, quantityChange);
             await _unitOfWork.SaveChangesAsync();
@@ -276,9 +276,9 @@ namespace WebAPI.Controllers
             var updated = await _unitOfWork.Products.GetByIdAsync(id);
 
             _logger.LogInformation("Stok guncellendi: {ProductId} - Degisim: {Change}, Yeni stok: {Stock}",
-                id, quantityChange, updated?.Stock);
+                id, quantityChange, updated?.UnitsInStock);
 
-            return Success(updated, $"Stok guncellendi. Yeni miktar: {updated?.Stock}");
+            return Success(updated, $"Stok guncellendi. Yeni miktar: {updated?.UnitsInStock}");
         }
 
         // =====================================================================

--- a/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/SalesController.cs
+++ b/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/SalesController.cs
@@ -317,11 +317,11 @@ namespace WebAPI.Controllers
                     }
 
                     // Stok kontrolu
-                    if (product.Stock < item.Quantity)
+                    if (product.UnitsInStock < item.Quantity)
                     {
                         await _unitOfWork.RollbackTransactionAsync();
                         return BadRequestResponse(
-                            $"Yetersiz stok: {product.Name}. Mevcut: {product.Stock}, Istenen: {item.Quantity}");
+                            $"Yetersiz stok: {product.Name}. Mevcut: {product.UnitsInStock}, Istenen: {item.Quantity}");
                     }
 
                     // Satis detayi olustur
@@ -329,13 +329,15 @@ namespace WebAPI.Controllers
                     {
                         SaleId = createdSale.Id,
                         ProductId = item.ProductId,
+                        ProductName = product.Name,
                         Quantity = item.Quantity,
                         UnitPrice = product.UnitPrice,
-                        TotalPrice = product.UnitPrice * item.Quantity
+                        Subtotal = product.UnitPrice * item.Quantity,
+                        TotalAmount = product.UnitPrice * item.Quantity
                     };
 
                     await _unitOfWork.SaleDetails.AddAsync(saleDetail);
-                    totalAmount += saleDetail.TotalPrice;
+                    totalAmount += saleDetail.TotalAmount;
 
                     // Stok dusumu
                     await _unitOfWork.Products.UpdateStockAsync(item.ProductId, -item.Quantity);

--- a/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/TechnicalServicesController.cs
+++ b/TeknoRoma_OnionArchitecture_Final/Presentation/WebAPI/Controllers/TechnicalServicesController.cs
@@ -232,7 +232,7 @@ namespace WebAPI.Controllers
             if (status == TechnicalServiceStatus.Tamamlandi ||
                 status == TechnicalServiceStatus.Cozulemedi)
             {
-                ticket.CompletedDate = DateTime.Now;
+                ticket.ResolvedDate = DateTime.Now;
             }
 
             await _unitOfWork.TechnicalServices.UpdateAsync(ticket);

--- a/TeknoRoma_OnionArchitecture_Final/Presentation/WebMVC/Controllers/ProductsController.cs
+++ b/TeknoRoma_OnionArchitecture_Final/Presentation/WebMVC/Controllers/ProductsController.cs
@@ -118,9 +118,9 @@ namespace WebMVC.Controllers
                     SupplierId = model.SupplierId,
                     IsActive = model.IsActive,
                     ImageUrl = model.ImageUrl,
-                    StockStatus = model.UnitsInStock <= 0 ? StockStatus.OutOfStock
-                        : model.UnitsInStock <= model.CriticalStockLevel ? StockStatus.LowStock
-                        : StockStatus.InStock
+                    StockStatus = model.UnitsInStock <= 0 ? StockStatus.Tukendi
+                        : model.UnitsInStock <= model.CriticalStockLevel ? StockStatus.Kritik
+                        : StockStatus.Yeterli
                 };
 
                 await _unitOfWork.Products.AddAsync(product);
@@ -210,9 +210,9 @@ namespace WebMVC.Controllers
                 product.SupplierId = model.SupplierId;
                 product.IsActive = model.IsActive;
                 product.ImageUrl = model.ImageUrl;
-                product.StockStatus = model.UnitsInStock <= 0 ? StockStatus.OutOfStock
-                    : model.UnitsInStock <= model.CriticalStockLevel ? StockStatus.LowStock
-                    : StockStatus.InStock;
+                product.StockStatus = model.UnitsInStock <= 0 ? StockStatus.Tukendi
+                    : model.UnitsInStock <= model.CriticalStockLevel ? StockStatus.Kritik
+                    : StockStatus.Yeterli;
 
                 _unitOfWork.Products.Update(product);
                 await _unitOfWork.SaveChangesAsync();
@@ -280,9 +280,9 @@ namespace WebMVC.Controllers
                 }
 
                 product.UnitsInStock = quantity;
-                product.StockStatus = quantity <= 0 ? StockStatus.OutOfStock
-                    : quantity <= product.CriticalStockLevel ? StockStatus.LowStock
-                    : StockStatus.InStock;
+                product.StockStatus = quantity <= 0 ? StockStatus.Tukendi
+                    : quantity <= product.CriticalStockLevel ? StockStatus.Kritik
+                    : StockStatus.Yeterli;
 
                 _unitOfWork.Products.Update(product);
                 await _unitOfWork.SaveChangesAsync();

--- a/TeknoRoma_OnionArchitecture_Final/Presentation/WebMVC/Views/Products/Details.cshtml
+++ b/TeknoRoma_OnionArchitecture_Final/Presentation/WebMVC/Views/Products/Details.cshtml
@@ -71,7 +71,7 @@
                             <tr>
                                 <th class="text-muted">Tedarikci:</th>
                                 <td>
-                                    <i class="bi bi-truck me-1"></i>@Model.Supplier?.Name
+                                    <i class="bi bi-truck me-1"></i>@Model.Supplier?.CompanyName
                                 </td>
                             </tr>
                         </table>
@@ -145,7 +145,7 @@
                                         </td>
                                         <td>@detail.Sale?.Customer?.FirstName @detail.Sale?.Customer?.LastName</td>
                                         <td>@detail.Quantity adet</td>
-                                        <td class="fw-medium">@detail.LineTotal.ToString("N2") TL</td>
+                                        <td class="fw-medium">@detail.TotalAmount.ToString("N2") TL</td>
                                         <td>@detail.Sale?.SaleDate.ToString("dd.MM.yyyy HH:mm")</td>
                                     </tr>
                                 }
@@ -203,7 +203,7 @@
                 </div>
                 <div class="d-flex justify-content-between mb-3">
                     <span class="text-muted">Toplam Satis Tutari:</span>
-                    <strong>@((Model.SaleDetails?.Sum(d => d.LineTotal) ?? 0).ToString("N2")) TL</strong>
+                    <strong>@((Model.SaleDetails?.Sum(d => d.TotalAmount) ?? 0).ToString("N2")) TL</strong>
                 </div>
                 <div class="d-flex justify-content-between mb-3">
                     <span class="text-muted">Stok Degeri:</span>


### PR DESCRIPTION
Property name corrections:
- TechnicalService.CompletedDate -> ResolvedDate
- Product.Stock -> UnitsInStock
- SaleDetail.TotalPrice -> TotalAmount
- SaleDetail.LineTotal -> TotalAmount
- Supplier.Name -> CompanyName
- StockStatus.InStock -> Yeterli
- StockStatus.LowStock -> Kritik
- StockStatus.OutOfStock -> Tukendi

Also added missing ProductName and Subtotal fields when creating SaleDetail.